### PR TITLE
Fix stopword replacement bug

### DIFF
--- a/slugify/slugify.py
+++ b/slugify/slugify.py
@@ -133,8 +133,8 @@ def slugify(text, entities=True, decimal=True, hexadecimal=True, max_length=0, w
     # remove stopwords
     if stopwords:
         stopwords_lower = [s.lower() for s in stopwords]
-        words = [w for w in text.split(separator) if w not in stopwords_lower]
-        text = separator.join(words)
+        words = [w for w in text.split('-') if w not in stopwords_lower]
+        text = '-'.join(words)
 
     # smart truncate if requested
     if max_length > 0:


### PR DESCRIPTION
The string is split using the separator parameter prior to having substituted it into the string, so stopwords don't work when using a separator other than "-".
